### PR TITLE
fix endpoint optional name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_private_dns_resolver" "this" {
 }
 
 resource "azurerm_private_dns_resolver_inbound_endpoint" "this" {
-  for_each = { for key, value in var.inbound_endpoints : value.name => value }
+  for_each = var.inbound_endpoints
 
   location                = local.location
   name                    = coalesce(each.value.name, "in-${each.key}-dnsResolver-inbound")
@@ -23,7 +23,7 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "this" {
 }
 
 resource "azurerm_private_dns_resolver_outbound_endpoint" "this" {
-  for_each = { for key, value in var.outbound_endpoints : value.name => value }
+  for_each = var.outbound_endpoints
 
   location                = local.location
   name                    = coalesce(each.value.name, "out-${each.key}-dnsResolver-outbound")


### PR DESCRIPTION
## Description

Variables `outbound_endpoints.name` and `inbound_endpoints.name` declared as optional, however, they are currently used as a map key in the `for_each` constructs.

This PR suggests using endpoint keys instead.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
